### PR TITLE
feat: add LeaphyBLE Bluetooth LE wrapper

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -9,5 +9,4 @@ url=https://github.com/leaphy-robotics/leaphy-extensions
 architectures=avr,esp32
 # Only include actually used library code in the resulting executable
 dot_a_linkage=true
-depends=Adafruit SSD1306,Adafruit GFX Library,Adafruit LSM303 Accel,Adafruit LIS2MDL,Adafruit BusIO,Adafruit_VL53L0X,Adafruit NeoPixel,EspSoftwareSerial
-
+depends=Adafruit SSD1306,Adafruit GFX Library,Adafruit LSM303 Accel,Adafruit LIS2MDL,Adafruit BusIO,Adafruit_VL53L0X,Adafruit NeoPixel,EspSoftwareSerial,ArduinoBLE

--- a/src/LeaphyBLE.cpp
+++ b/src/LeaphyBLE.cpp
@@ -1,0 +1,59 @@
+#include "LeaphyBLE.h"
+#include <ArduinoBLE.h>
+#include <utility/BLEUuid.h>
+
+#define LEAPHY_BLE_SERVICE_UUID "a3a671c0-a063-444d-86b9-34fd0255d897" // This Bluetooth service should be the same for all Leaphy devices. It is used to separate them from other Bluetooth devices.
+
+BLEService leaphyService(LEAPHY_BLE_SERVICE_UUID);
+
+bool LeaphyBLE::initialize(const char *deviceName)
+{
+  if(!BLE.begin()) {
+    return false;
+  }
+
+  BLE.setLocalName(deviceName);
+  BLE.addService(leaphyService);
+  BLE.setAdvertisedService(leaphyService);
+  BLE.advertise();
+  return true;
+}
+
+BLEBoolCharacteristic LeaphyBLE::addBinaryCharacteristic(const char *name, bool initialValue)
+{
+    BLEUuid uuid(name); // Turn name into UUID
+    BLEBoolCharacteristic* characteristic = new BLEBoolCharacteristic(uuid.str(), BLERead | BLEWrite);
+    characteristic->writeValue(initialValue);
+    leaphyService.addCharacteristic(*characteristic); // Hook into service
+
+    characteristicNames[characteristicCount] = name;
+    characteristics[characteristicCount] = characteristic;
+    characteristicCount++;
+
+    return *characteristic;
+}
+
+BLEStringCharacteristic LeaphyBLE::addStringCharacteristic(const char *name, const char *initialValue)
+{
+    BLEUuid uuid(name); // Turn name into UUID
+    BLEStringCharacteristic* characteristic = new BLEStringCharacteristic(uuid.str(), BLERead | BLEWrite, 20);
+    characteristic->writeValue(initialValue);
+    leaphyService.addCharacteristic(*characteristic); // Hook into service
+
+    characteristicNames[characteristicCount] = name;
+    characteristics[characteristicCount] = characteristic;
+    characteristicCount++;
+
+    return *characteristic;
+}
+
+BLECharacteristic* LeaphyBLE::getCharacteristicByName(const char *name)
+{
+    for (int i = 0; i < characteristicCount; i++) {
+        if (characteristicNames[i] == name) {
+            return characteristics[i];
+        }
+    }
+
+    return nullptr; // characteristic not found
+}

--- a/src/LeaphyBLE.h
+++ b/src/LeaphyBLE.h
@@ -1,0 +1,20 @@
+#ifndef _LEAPHY_BLE_H
+#define _LEAPHY_BLE_H
+
+#include <ArduinoBLE.h>
+
+class LeaphyBLE
+{
+public:
+  bool initialize(const char *deviceName);
+  BLEBoolCharacteristic addBinaryCharacteristic(const char *name, bool initialValue);
+  BLEStringCharacteristic addStringCharacteristic(const char *name, const char *initialValue);
+  BLECharacteristic* getCharacteristicByName(const char *name);
+
+private:
+  String characteristicNames[10];
+  BLECharacteristic* characteristics[10];
+  int characteristicCount = 0;
+};
+
+#endif


### PR DESCRIPTION
As a better solution than to maintain an [ArduinoBLE](https://github.com/arduino-libraries/ArduinoBLE) fork, instead add a wrapper of it to `leaphy-extensions`.

Documented in: https://github.com/leaphy-robotics/leaphy-webbased-svelte/issues/146
--
* https://github.com/leaphy-robotics/leaphy-webbased-svelte/pull/171
* https://github.com/leaphy-robotics/leaphy-blocks/pull/148